### PR TITLE
Fix garbage collection

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -40,7 +40,8 @@ type instancePool struct {
 	runtime  wazero.Runtime
 }
 
-// Module instances can't be garbage collected directly so we use
+// Module instances can't be garbage collected directly. This wrapper type has no external references so it can be
+// garbage collected.
 type wrapper struct {
 	mod api.Module
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -96,10 +96,12 @@ func TestModule(t *testing.T) {
 		})
 	})
 	t.Run(`cleanup`, func(t *testing.T) {
-		pool, err := New(ctx, runtime, src, cfg, WithLimit(1))
+		pool, err := New(ctx, runtime, src, cfg, WithLimit(2))
 		if err != nil {
 			t.Fatalf(`%v`, err)
 		}
+		goruntime.GC()
+		goruntime.GC()
 		for range 5 {
 			var mod = pool.Get()
 			goruntime.GC()


### PR DESCRIPTION
As long as each runtime store maintains a [linked list](https://github.com/tetratelabs/wazero/blob/v1.9.0/internal/wasm/store.go#L39) containing every module instance created, they will never be garbage collected until the runtime is closed. 

This PR introduces a wrapper object that will be garbage collected and uses the new [runtime.AddCleanup](https://pkg.go.dev/runtime@master#AddCleanup) feature added in go 1.24 to ensure that the module instance is closed when the wrapper is garbage collected.

Also adds tests to assert garbage collection is functioning as expected.

(Thanks @ckaznocha)