### PR TITLE
Add exported function cache for convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,18 +78,22 @@ in other ways.
 
 ```go
 > make bench
-BenchmarkModule/add/linear-16                    7618785               159.1 ns/op
-BenchmarkModule/add/parallel-2-16                2910556               417.4 ns/op
-BenchmarkModule/add/parallel-4-16                2496784               491.0 ns/op
-BenchmarkModule/add/parallel-8-16                1883826               652.5 ns/op
-BenchmarkModule/add/parallel-16-16               1665798               729.2 ns/op
-BenchmarkModule/add/parallel-0-16                3688936               347.6 ns/op
-BenchmarkModule/microsleep/linear-16               17337             70915 ns/op
-BenchmarkModule/microsleep/parallel-2-16           84289             14626 ns/op
-BenchmarkModule/microsleep/parallel-4-16          110790             10413 ns/op
-BenchmarkModule/microsleep/parallel-8-16          694129              2046 ns/op
-BenchmarkModule/microsleep/parallel-16-16        1261778               954.5 ns/op
-BenchmarkModule/microsleep/parallel-0-16         2362352               496.5 ns/op
+BenchmarkModule/add/raw-16                      31112986                38.95 ns/op
+BenchmarkModule/add/wrapped-16                  26988614                45.59 ns/op
+BenchmarkModule/add/pooled-16                    7362813               160.9 ns/op
+BenchmarkModule/add/parallel-2-16                2847218               445.3 ns/op
+BenchmarkModule/add/parallel-4-16                2397896               508.7 ns/op
+BenchmarkModule/add/parallel-8-16                1846426               656.6 ns/op
+BenchmarkModule/add/parallel-16-16               1676278               745.8 ns/op
+BenchmarkModule/add/parallel-0-16                3551059               331.8 ns/op
+BenchmarkModule/microsleep/raw-16                  30891             40574 ns/op
+BenchmarkModule/microsleep/wrapped-16              25706             48160 ns/op
+BenchmarkModule/microsleep/pooled-16               12202             94872 ns/op
+BenchmarkModule/microsleep/parallel-2-16           83138             14738 ns/op
+BenchmarkModule/microsleep/parallel-4-16          109393             11234 ns/op
+BenchmarkModule/microsleep/parallel-8-16          731980              1714 ns/op
+BenchmarkModule/microsleep/parallel-16-16        1258392               969.3 ns/op
+BenchmarkModule/microsleep/parallel-0-16         2359347               517.5 ns/op
 ```
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -78,16 +78,18 @@ in other ways.
 
 ```go
 > make bench
-BenchmarkModule/add/linear-16                    1181882              1009 ns/op
-BenchmarkModule/add/parallel-2-16                1038873              1042 ns/op
-BenchmarkModule/add/parallel-4-16                1000000              1070 ns/op
-BenchmarkModule/add/parallel-16-16               1000000              1307 ns/op
-BenchmarkModule/add/parallel-0-16                3431593               325.1 ns/op
-BenchmarkModule/microsleep/linear-16                6487            156801 ns/op
-BenchmarkModule/microsleep/parallel-2-16           93465             14592 ns/op
-BenchmarkModule/microsleep/parallel-4-16          696016              2530 ns/op
-BenchmarkModule/microsleep/parallel-16-16        1000000              1678 ns/op
-BenchmarkModule/microsleep/parallel-0-16         1000000              1417 ns/op
+BenchmarkModule/add/linear-16                    7618785               159.1 ns/op
+BenchmarkModule/add/parallel-2-16                2910556               417.4 ns/op
+BenchmarkModule/add/parallel-4-16                2496784               491.0 ns/op
+BenchmarkModule/add/parallel-8-16                1883826               652.5 ns/op
+BenchmarkModule/add/parallel-16-16               1665798               729.2 ns/op
+BenchmarkModule/add/parallel-0-16                3688936               347.6 ns/op
+BenchmarkModule/microsleep/linear-16               17337             70915 ns/op
+BenchmarkModule/microsleep/parallel-2-16           84289             14626 ns/op
+BenchmarkModule/microsleep/parallel-4-16          110790             10413 ns/op
+BenchmarkModule/microsleep/parallel-8-16          694129              2046 ns/op
+BenchmarkModule/microsleep/parallel-16-16        1261778               954.5 ns/op
+BenchmarkModule/microsleep/parallel-0-16         2362352               496.5 ns/op
 ```
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ BenchmarkModule/microsleep/parallel-16-16        1258392               969.3 ns/
 BenchmarkModule/microsleep/parallel-0-16         2359347               517.5 ns/op
 ```
 
+These benchmark results illustrate the throughput advantages pooling can have for high latency operations and the throughput disadvantages it can introduce for low latency operations.
+
+![Effect of Latency and Concurrency on Throughput](https://github.com/user-attachments/assets/03d9806d-aa81-4d39-8855-50c08f4d01c2)
+
+Generally, this instance pool will be more useful for modules that make callbacks to host modules and less useful for pure functional modules.
+
 ## Roadmap
 
 This project is in `Alpha`. Breaking API changes should be expected until Beta.

--- a/pool_test.go
+++ b/pool_test.go
@@ -102,13 +102,15 @@ func TestModule(t *testing.T) {
 		goruntime.GC()
 		goruntime.GC()
 		for range 5 {
-			var mod = pool.Get()
+			w := pool.Get()
+			mod := w.(*wrapper).Module
 			goruntime.GC()
 			goruntime.GC()
 			if mod.IsClosed() {
 				t.Fatal(`Module should not be closed.`)
 			}
-			pool.Put(mod)
+			pool.Put(w)
+			w = nil
 			goruntime.GC()
 			goruntime.GC()
 			if !mod.IsClosed() {
@@ -129,11 +131,12 @@ func BenchmarkModule(b *testing.B) {
 		"microsleep",
 	} {
 		b.Run(name, func(b *testing.B) {
+			goruntime.GC()
+			pool, err := New(ctx, runtime, src, cfg)
+			if err != nil {
+				b.Fatalf(`%v`, err)
+			}
 			b.Run(`linear`, func(b *testing.B) {
-				pool, err := New(ctx, runtime, src, cfg)
-				if err != nil {
-					b.Fatalf(`%v`, err)
-				}
 				for b.Loop() {
 					pool.With(func(mod api.Module) {
 						stack, err := mod.ExportedFunction(name).Call(ctx, 1, 1)
@@ -146,7 +149,8 @@ func BenchmarkModule(b *testing.B) {
 					})
 				}
 			})
-			for _, n := range []int{2, 4, 16, 0} {
+			for _, n := range []int{2, 4, 8, 16, 0} {
+				goruntime.GC()
 				pool, err := New(ctx, runtime, src, cfg, WithLimit(n))
 				if err != nil {
 					b.Fatalf(`%v`, err)


### PR DESCRIPTION
Caching exported functions is a common performance optimization when working with individual module instances. Clients of this instance pool cannot cache exported functions across pool acquisitions so it is more convenient for the pool to cache exported functions transparently.

Also prevents an edge case where modules may be unexpectedly closed if clients retained references to modules after putting them back in the pool.